### PR TITLE
Cambios imprescindibles en el facturascripts.ini

### DIFF
--- a/facturascripts.ini
+++ b/facturascripts.ini
@@ -1,1 +1,4 @@
-version = 1
+version = 2
+version_url = "https://raw.githubusercontent.com/outthesystem/Tienda/master/facturascripts.ini"
+update_url = "https://github.com/outthesystem/Tienda/archive/master.zip"
+require = 'facturacion_base'


### PR DESCRIPTION
He añadido version_url y update_url para que FacturaScripts pueda actualizar este plugin con los cambios que se vayan haciendo en el repositiorio. Además del require para impedir que se pueda activar el plugin sin tener facturacion_base activado.